### PR TITLE
added few dhivehi bad words

### DIFF
--- a/Dictionaries/Default.json
+++ b/Dictionaries/Default.json
@@ -10218,5 +10218,17 @@
     {
         "language": "zh",
         "word": "\u9f9f\u5934"
+    },
+    {
+    "language": "dhiv",
+    "word": "\u0784\u07aa\u0783\u07a8"
+    },
+    {
+    "language": "dhiv",
+    "word": "\u078a\u07af\u0787\u07b0"
+    },
+    {
+    "language": "dhiv",
+    "word": "\u0782\u07a6\u078e\u07ab\u0784\u07a6\u0785\u07aa"
     }
 ]


### PR DESCRIPTION
The Maldivian language, whose endonym is Dhivehi or Divehi, is an Indo-Aryan language spoken in the South Asian island country of the Maldives.

I will add more later :))