### PR TITLE
Extended blocker to provide a way to only use bad words of specific languages

### DIFF
--- a/Builder.php
+++ b/Builder.php
@@ -25,10 +25,14 @@ class Builder
      *
      * @param string $type
      * @param string $library
+     * @param array  $languages Language codes of the bad words that should be checked against.
+     *                          Keep empty to check against all words.
+     *                          Example: Passing ['en', 'de'] means that text is only checked against
+     *                          English and German words from the dictionary.
      *
      * @return \ConsoleTVs\Profanity\Classes\Blocker
      */
-    public static function blocker($text, $blocker = '****')
+    public static function blocker($text, $blocker = '****', $languages = [])
     {
         return new Blocker($text, $blocker);
     }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Alias (optional):
 $words = 'My bad word bitch';
 $clean_words = \ConsoleTVs\Profanity\Builder::blocker($words)->filter();
 // My bad word *****
+
+// Filter words only by English and German bad words.
+$clean_words = \ConsoleTVs\Profanity\Builder::blocker($words, languages: ['en', 'de'])->filter();
 ```
 
 #### Laravel
@@ -93,11 +96,13 @@ class HomeController extends Controller
 
 #### Constructor
 
--   blocker($text, $blocker = '****')
+-   blocker($text, $blocker = '****', $languages = [])
 
     Setup the text and the blocker to use.
 
     *note:* The blocker defaults to ```****```
+
+    *note:* Pass language codes to reduce the list of bad words that are taken into account.  
 
 #### Class Methods
 


### PR DESCRIPTION
This addresses #20.

Without this change the filter is not really usable for German texts with the default dictionary, because the normal regularly used word 'nicht' is a bad word in Dutch.