### PR TITLE
Update Blocker.php

### DIFF
--- a/Classes/Blocker.php
+++ b/Classes/Blocker.php
@@ -144,7 +144,7 @@ class Blocker
             }
             $pattern = "/\b{$value['word']}\b/iu";
 
-            return preg_match($pattern, $this->text, $matches, PREG_UNMATCHED_AS_NULL);
+            return preg_match($pattern, $this->text ?? '', $matches, PREG_UNMATCHED_AS_NULL);
         })->map(function ($value) {
             return [
                 'language' => $value['language'],


### PR DESCRIPTION
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated , consoletvs/profanity/Classes/Blocker.php on line 147